### PR TITLE
Remove category for tickets to allow multiple ticket systems

### DIFF
--- a/bundle-artifacts/prereqs/connectorschema.yaml
+++ b/bundle-artifacts/prereqs/connectorschema.yaml
@@ -101,7 +101,6 @@ spec:
     iconFileSize: 96
     categories: 
       - "{{connector.common.category.notifications}}"
-      - "{{connector.common.category.tickets}}"
     url: https://www.ibm.com/docs/en/cloud-paks/cloud-pak-aiops
     apiAdaptor: grpc
     datasourceType: tickets


### PR DESCRIPTION
If service now is present, it will prevent other connectors from being created.